### PR TITLE
remove shadow in the icon of crossproduct. 

### DIFF
--- a/lib/arithmetic/icons/crossproduct.svg
+++ b/lib/arithmetic/icons/crossproduct.svg
@@ -81,19 +81,6 @@
          d="M 8.7185878,4.0337352 L -2.2072895,0.016013256 L 8.7185884,-4.0017078 C 6.9730900,-1.6296469 6.9831476,1.6157441 8.7185878,4.0337352 z "
          transform="scale(0.3) translate(-2.3,0)" />
     </marker>
-    <filter
-       inkscape:collect="always"
-       style="color-interpolation-filters:sRGB"
-       id="filter975"
-       x="-0.01947072"
-       width="1.0389414"
-       y="-0.031275251"
-       height="1.0625505">
-      <feGaussianBlur
-         inkscape:collect="always"
-         stdDeviation="0.088223377"
-         id="feGaussianBlur977" />
-    </filter>
   </defs>
   <sodipodi:namedview
      id="base"
@@ -102,20 +89,20 @@
      borderopacity="1.0"
      inkscape:pageopacity="0.0"
      inkscape:pageshadow="2"
-     inkscape:zoom="15.999999"
-     inkscape:cx="37.240987"
-     inkscape:cy="33.009723"
+     inkscape:zoom="7.9999995"
+     inkscape:cx="33.133764"
+     inkscape:cy="39.534138"
      inkscape:document-units="mm"
-     inkscape:current-layer="g1064"
+     inkscape:current-layer="g894-4"
      showgrid="false"
      fit-margin-top="2"
      fit-margin-left="2"
      fit-margin-right="2"
      fit-margin-bottom="2"
-     inkscape:window-width="3200"
-     inkscape:window-height="1645"
-     inkscape:window-x="0"
-     inkscape:window-y="41"
+     inkscape:window-width="1920"
+     inkscape:window-height="1040"
+     inkscape:window-x="1920"
+     inkscape:window-y="0"
      inkscape:window-maximized="1" />
   <metadata
      id="metadata5">
@@ -140,159 +127,89 @@
       <g
          id="g1064"
          transform="matrix(1.2646968,0,0,1.2646968,-16.50459,-22.814155)">
-        <g
-           id="g894-7"
-           transform="translate(0.02615086,0.03922629)"
-           style="opacity:0.291;filter:url(#filter975)">
-          <ellipse
-             ry="1.3764409"
-             rx="5.0738802"
-             cy="88.876236"
-             cx="63.289459"
-             id="path897-1"
-             style="opacity:1;fill:#ffffff;fill-opacity:0.35350324;stroke:#666666;stroke-width:0.08131316;stroke-linecap:round;stroke-miterlimit:4;stroke-dasharray:0.08131316, 0.16262631999999999;stroke-dashoffset:0;stroke-opacity:1" />
-          <path
-             inkscape:connector-curvature="0"
-             id="path899-7"
-             d="M 63.268808,88.632044 V 83.667972"
-             style="fill:#ff00ff;stroke:#ff00ff;stroke-width:0.08807719;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
-          <path
-             inkscape:connector-curvature="0"
-             id="path901-2"
-             d="m 63.268808,88.632044 2.078394,-0.950868"
-             style="fill:none;stroke:#ff0000;stroke-width:0.08807719;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
-          <path
-             inkscape:connector-curvature="0"
-             id="path903-7"
-             d="m 63.268808,88.632044 4.641808,0.709524"
-             style="fill:none;stroke:#0000ff;stroke-width:0.08807719;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
-          <path
-             inkscape:connector-curvature="0"
-             id="path905-2"
-             d="m 63.116899,83.915147 0.157058,-0.432555 0.154483,0.427405 z"
-             style="fill:#ff00ff;stroke:#ff00ff;stroke-width:0.08807719;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
-          <path
-             sodipodi:nodetypes="cccc"
-             inkscape:connector-curvature="0"
-             id="path905-8-2"
-             d="m 64.869582,87.817332 0.439387,-0.139798 -0.170555,0.195346 z"
-             style="fill:#ff0000;stroke:#ff0000;stroke-width:0.08807719;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
-          <path
-             sodipodi:nodetypes="cccc"
-             inkscape:connector-curvature="0"
-             id="path905-5-6"
-             d="m 67.62637,89.184081 0.315195,0.175694 -0.49778,0.01693 z"
-             style="fill:#0000ff;stroke:#0000ff;stroke-width:0.08807719;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
-          <circle
-             r="0.087133162"
-             cy="88.624504"
-             cx="63.272194"
-             id="path937-1"
-             style="opacity:1;fill:#1a1a1a;fill-opacity:1;stroke:#1a1a1a;stroke-width:0.08807719;stroke-linecap:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1" />
-          <text
-             id="text871-0"
-             y="87.485657"
-             x="65.616463"
-             style="font-style:normal;font-weight:normal;font-size:8.36827755px;line-height:1.25;font-family:sans-serif;letter-spacing:0px;word-spacing:0px;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.20920692"
-             xml:space="preserve"><tspan
-               style="font-size:1.11577034px;fill:#ff0000;stroke-width:0.20920692"
-               y="87.485657"
-               x="65.616463"
-               id="tspan869-6"
-               sodipodi:role="line">A</tspan></text>
-          <text
-             id="text871-3-1"
-             y="89.803825"
-             x="68.403709"
-             style="font-style:normal;font-weight:normal;font-size:8.36827755px;line-height:1.25;font-family:sans-serif;letter-spacing:0px;word-spacing:0px;fill:#0000ff;fill-opacity:1;stroke:none;stroke-width:0.20920692"
-             xml:space="preserve"><tspan
-               style="font-size:1.11577034px;fill:#0000ff;stroke-width:0.20920692"
-               y="89.803825"
-               x="68.403709"
-               id="tspan869-1-5"
-               sodipodi:role="line">B</tspan></text>
-        </g>
         <text
            xml:space="preserve"
            style="font-style:normal;font-weight:normal;font-size:14.53116798px;line-height:1.25;font-family:sans-serif;letter-spacing:0px;word-spacing:0px;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.36327919"
-           x="58.175198"
-           y="82.576408"
-           id="text884"><tspan
+           x="57.772049"
+           y="82.463333"
+           id="text884-3"><tspan
              sodipodi:role="line"
-             id="tspan882"
-             x="58.175198"
-             y="82.576408"
+             id="tspan882-0"
+             x="57.772049"
+             y="82.463333"
              style="font-size:4.84372187px;stroke-width:0.36327919"><tspan
-               style="fill:#333333"
-               id="tspan861">A∧B</tspan></tspan></text>
+               style="fill:#333333;stroke-width:0.36327919"
+               id="tspan861-4">A∧B</tspan></tspan></text>
         <g
-           id="g894">
+           transform="translate(-0.32169135,0.01844089)"
+           id="g894-4">
           <ellipse
-             ry="1.3764409"
-             rx="5.0738802"
-             cy="88.876236"
-             cx="63.289459"
-             id="path897"
-             style="opacity:1;fill:#ffffff;fill-opacity:0.35350324;stroke:#666666;stroke-width:0.08131316;stroke-linecap:round;stroke-miterlimit:4;stroke-dasharray:0.08131316, 0.16262632;stroke-dashoffset:0;stroke-opacity:1" />
+             ry="1.460265"
+             rx="5.3828754"
+             cy="88.369186"
+             cx="63.263317"
+             id="path897-4"
+             style="opacity:1;fill:#ffffff;fill-opacity:0.35350324;stroke:#666666;stroke-width:0.16777131;stroke-linecap:round;stroke-miterlimit:4;stroke-dasharray:0.16777131, 0.33554261;stroke-dashoffset:0;stroke-opacity:1" />
           <path
              inkscape:connector-curvature="0"
-             id="path899"
-             d="M 63.268808,88.632044 V 83.667972"
-             style="fill:#ff00ff;stroke:#ff00ff;stroke-width:0.08807719;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
+             id="path899-4"
+             d="M 63.268808,88.21363 V 83.667972"
+             style="fill:#ff00ff;stroke:#ff00ff;stroke-width:0.15814067;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+             sodipodi:nodetypes="cc" />
           <path
              inkscape:connector-curvature="0"
-             id="path901"
-             d="m 63.268808,88.632044 2.078394,-0.950868"
-             style="fill:none;stroke:#ff0000;stroke-width:0.08807719;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
+             id="path901-7"
+             d="m 63.268808,88.21363 2.078394,-0.950868"
+             style="fill:none;stroke:#ff0000;stroke-width:0.15814067;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
           <path
              inkscape:connector-curvature="0"
-             id="path903"
-             d="m 63.268808,88.632044 4.641808,0.709524"
-             style="fill:none;stroke:#0000ff;stroke-width:0.08807719;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
+             id="path903-6"
+             d="m 63.268808,88.21363 4.641808,0.709524"
+             style="fill:none;stroke:#0000ff;stroke-width:0.15814067;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
           <path
              inkscape:connector-curvature="0"
-             id="path905"
-             d="m 63.116899,83.915147 0.157058,-0.432555 0.154483,0.427405 z"
-             style="fill:#ff00ff;stroke:#ff00ff;stroke-width:0.08807719;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
-          <path
-             sodipodi:nodetypes="cccc"
-             inkscape:connector-curvature="0"
-             id="path905-8"
-             d="m 64.869582,87.817332 0.439387,-0.139798 -0.170555,0.195346 z"
-             style="fill:#ff0000;stroke:#ff0000;stroke-width:0.08807719;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
+             id="path905-3"
+             d="m 63.043465,83.866767 0.234488,-0.645806 0.230644,0.638117 z"
+             style="fill:#ff00ff;stroke:#ff00ff;stroke-width:0.13149954;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
           <path
              sodipodi:nodetypes="cccc"
              inkscape:connector-curvature="0"
-             id="path905-5"
-             d="m 67.62637,89.184081 0.315195,0.175694 -0.49778,0.01693 z"
-             style="fill:#0000ff;stroke:#0000ff;stroke-width:0.08807719;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
+             id="path905-8-1"
+             d="m 64.85406,87.358932 0.738154,-0.234856 -0.286526,0.328174 z"
+             style="fill:#ff0000;stroke:#ff0000;stroke-width:0.14796655;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
+          <path
+             sodipodi:nodetypes="cccc"
+             inkscape:connector-curvature="0"
+             id="path905-5-7"
+             d="m 67.379473,88.627088 0.531143,0.296066 -0.838821,0.02853 z"
+             style="fill:#0000ff;stroke:#0000ff;stroke-width:0.14842084;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
           <circle
              r="0.087133162"
-             cy="88.624504"
+             cy="88.206093"
              cx="63.272194"
-             id="path937"
+             id="path937-5"
              style="opacity:1;fill:#1a1a1a;fill-opacity:1;stroke:#1a1a1a;stroke-width:0.08807719;stroke-linecap:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1" />
           <text
-             id="text871"
-             y="87.485657"
-             x="65.616463"
+             id="text871-9"
+             y="86.762138"
+             x="66.092621"
              style="font-style:normal;font-weight:normal;font-size:8.36827755px;line-height:1.25;font-family:sans-serif;letter-spacing:0px;word-spacing:0px;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.20920692"
              xml:space="preserve"><tspan
-               style="font-size:1.11577034px;fill:#ff0000;stroke-width:0.20920692"
-               y="87.485657"
-               x="65.616463"
-               id="tspan869"
+               style="font-size:1.67365539px;fill:#ff0000;stroke-width:0.20920692"
+               y="86.762138"
+               x="66.092621"
+               id="tspan869-62"
                sodipodi:role="line">A</tspan></text>
           <text
-             id="text871-3"
-             y="89.803825"
-             x="68.403709"
+             id="text871-3-17"
+             y="90.078415"
+             x="68.482162"
              style="font-style:normal;font-weight:normal;font-size:8.36827755px;line-height:1.25;font-family:sans-serif;letter-spacing:0px;word-spacing:0px;fill:#0000ff;fill-opacity:1;stroke:none;stroke-width:0.20920692"
              xml:space="preserve"><tspan
-               style="font-size:1.11577034px;fill:#0000ff;stroke-width:0.20920692"
-               y="89.803825"
-               x="68.403709"
-               id="tspan869-1"
+               style="font-size:1.67365539px;fill:#0000ff;stroke-width:0.20920692"
+               y="90.078415"
+               x="68.482162"
+               id="tspan869-1-8"
                sodipodi:role="line">B</tspan></text>
         </g>
       </g>


### PR DESCRIPTION
Shadows generates warning when papyrus tries to parse it.