### PR TITLE
solving symmetry issues for convolution function. 

### DIFF
--- a/lib/neural_processing/basicneuronal/basicneuronal.h
+++ b/lib/neural_processing/basicneuronal/basicneuronal.h
@@ -212,8 +212,8 @@ class Conv_functor{
          	{
                  for( typename ArgType::Index j = 0; j < mcols; j++)
                  {
-			typename ArgType::Index zrow = irow + i - mrows/2.0 ;
-                        typename ArgType::Index zcol = icol + j - mcols/2.0 ;
+												typename ArgType::Index zrow = irow + i+mrows%2 - (mrows+mrows%2)/2.0 ; // rule differs whether mrows is odd (mrows%2!=0) or even (mrows%2=0)
+                        typename ArgType::Index zcol = icol + j+mcols%2 - (mcols+mcols%2)/2.0 ; // same for mcols
 
                         if( circular )
                         {


### PR DESCRIPTION
zrow/zcol construction was ok for even number of neurons, but output a mask asymmetry and ugly behvior on index 0 for odd number of neurons.